### PR TITLE
Add resnet example to benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,11 @@ add_executable(benchmarker_large_stride_torch benchmarker_large_stride_torch.f90
 target_link_libraries(benchmarker_large_stride_torch PRIVATE FTorch::ftorch )
 target_sources(benchmarker_large_stride_torch PRIVATE benchmarker_utils.f90)
 
+# resnet test
+add_executable(benchmarker_resnet_torch benchmarker_resnet_torch.f90)
+target_link_libraries(benchmarker_resnet_torch PRIVATE FTorch::ftorch )
+target_sources(benchmarker_resnet_torch PRIVATE benchmarker_utils.f90)
+
 # Make sure python present
 find_package(Python REQUIRED COMPONENTS Development)
 
@@ -105,6 +110,15 @@ target_link_libraries(benchmarker_large_stride_forpy PRIVATE Python::Python)
 
 if (USETS)
     target_compile_definitions(benchmarker_large_stride_forpy PUBLIC USETS)
+endif()
+
+option(USETS "Use torchscript format for forpy test" OFF)
+add_executable(benchmarker_resnet_forpy benchmarker_resnet_forpy.f90)
+target_sources(benchmarker_resnet_forpy PRIVATE ${forpy_SOURCE_DIR}/forpy_mod.F90 benchmarker_utils.f90)
+target_link_libraries(benchmarker_resnet_forpy PRIVATE Python::Python)
+
+if (USETS)
+    target_compile_definitions(benchmarker_resnet_forpy PUBLIC USETS)
 endif()
 
 add_executable(benchmarker_forpy benchmarker_forpy.f90)

--- a/benchmarker_resnet_forpy.f90
+++ b/benchmarker_resnet_forpy.f90
@@ -1,0 +1,114 @@
+program benchmark_resnet
+
+  use, intrinsic :: iso_c_binding
+  use :: utils, only : assert_real_2d, setup, error_mesg, print_time_stats
+  use :: forpy_mod, only: import_py, module_py, call_py, object, ndarray, &
+                          forpy_initialize, forpy_finalize, tuple, tuple_create, &
+                          ndarray_create, err_print, call_py_noret, list, &
+                          get_sys_path, ndarray_create_nocopy, str, str_create
+
+  implicit none
+
+  integer :: i, n
+  real :: start_time, end_time
+  real, allocatable :: durations(:)
+  real, dimension(:,:,:,:), allocatable, asynchronous :: in_data
+  real, dimension(:,:), allocatable, asynchronous :: out_data
+
+  integer :: ie
+  type(module_py) :: run_emulator
+  type(list) :: paths
+  type(object) :: model
+  type(tuple) :: args
+  type(str) :: py_model_dir
+#ifdef USETS
+  type(str) :: filename
+#endif
+
+  character(len=:), allocatable :: model_dir, model_name
+  character(len=128) :: msg
+  integer :: ntimes
+
+  type(ndarray) :: out_data_nd, in_data_nd
+
+  print *, "====== FORPY ======"
+
+  call setup(model_dir, model_name, ntimes, n)
+
+  allocate(in_data(1, 3, 224, 224))
+  allocate(out_data(1, 1000))
+  allocate(durations(ntimes))
+
+  ie = forpy_initialize()
+  ie = str_create(py_model_dir, trim(model_dir))
+  ie = get_sys_path(paths)
+  ie = paths%append(py_model_dir)
+
+  ! import python modules to `run_emulator`
+  ie = import_py(run_emulator, trim(model_name))
+  if (ie .ne. 0) then
+      call err_print
+      call error_mesg(__FILE__, __LINE__, "forpy model not loaded")
+  end if
+
+#ifdef USETS
+  print *, "load torchscript model"
+  ! load torchscript saved model
+  ie = tuple_create(args,1)
+  ie = str_create(filename, trim(model_dir//'/saved_resnet18_model_cpu.pt'))
+  ie = args%setitem(0, filename)
+  ie = call_py(model, run_emulator, "initialize_ts", args)
+  call args%destroy
+#else
+  print *, "generate model in python runtime"
+  ! use python module `run_emulator` to load a trained model
+  ie = call_py(model, run_emulator, "initialize")
+#endif
+  if (ie .ne. 0) then
+      call err_print
+      call error_mesg(__FILE__, __LINE__, "call to `initialize` failed")
+  end if
+
+  do i = 1, ntimes
+
+    in_data = 1.0d0
+
+    call cpu_time(start_time)
+
+    ! creates numpy arrays
+    ie = ndarray_create_nocopy(in_data_nd, in_data)
+    ie = ndarray_create_nocopy(out_data_nd, out_data)
+
+    ! create model input args as tuple
+    ie = tuple_create(args,3)
+    ie = args%setitem(0, model)
+    ie = args%setitem(1, in_data_nd)
+    ie = args%setitem(2, out_data_nd)
+
+    ie = call_py_noret(run_emulator, "compute", args)
+    if (ie .ne. 0) then
+        call err_print
+        call error_mesg(__FILE__, __LINE__, "inference call failed")
+    end if
+
+    ! Clean up.
+    call out_data_nd%destroy
+    call in_data_nd%destroy
+    call args%destroy
+
+    call cpu_time(end_time)
+    durations(i) = end_time-start_time
+    ! the forward model is deliberately non-symmetric to check for difference in Fortran and C--type arrays.
+    write(msg, '(A, I8, A, F10.3, A)') "check iteration ", i, " (", durations(i), " s)"
+    print *, trim(msg)
+    write (*,*) out_data(1, 1000)
+    ! call assert_real_2d(in_data, out_data/2., test_name=msg)
+  end do
+
+  call print_time_stats(durations)
+
+  deallocate(in_data)
+  deallocate(out_data)
+  deallocate(durations)
+
+end program benchmark_resnet

--- a/benchmarker_resnet_torch.f90
+++ b/benchmarker_resnet_torch.f90
@@ -1,0 +1,80 @@
+program benchmark_resnet_test
+
+  use, intrinsic :: iso_c_binding
+  use :: utils, only : assert_real_2d, setup, print_time_stats
+  use :: ftorch
+
+  implicit none
+
+  integer :: i, ii, n
+  real :: start_time, end_time
+  real, allocatable :: durations(:)
+
+  real(c_float), dimension(:,:,:,:), allocatable, target :: in_data
+  integer(c_int), parameter :: n_inputs = 1
+  real(c_float), dimension(:,:), allocatable, target :: out_data
+
+  integer(c_int), parameter :: in_dims = 4
+  integer(c_int64_t) :: in_shape(in_dims) = [1, 3, 224, 224]
+  integer(c_int) :: in_layout(in_dims) = [1,2,3,4]
+  integer(c_int), parameter :: out_dims = 2
+  integer(c_int64_t) :: out_shape(out_dims) = [1, 1000]
+  integer(c_int) :: out_layout(out_dims) = [1,2]
+
+  character(len=:), allocatable :: model_dir, model_name
+  character(len=128) :: msg
+  integer :: ntimes
+
+  type(torch_module) :: model
+  type(torch_tensor), dimension(1) :: in_tensor
+  type(torch_tensor) :: out_tensor
+
+  print *, "====== DIRECT COUPLED ======"
+
+  call setup(model_dir, model_name, ntimes, n)
+
+  allocate(in_data(in_shape(1), in_shape(2), in_shape(3), in_shape(4)))
+  allocate(out_data(out_shape(1), out_shape(2)))
+  allocate(durations(ntimes))
+
+  model = torch_module_load(model_dir//"/"//model_name)
+
+  do i = 1, ntimes
+
+    ! Initialise data
+    in_data = 1.0d0
+
+    call cpu_time(start_time)
+
+    ! Create input and output tensors for the model.
+    in_tensor(1) = torch_tensor_from_blob(c_loc(in_data), in_dims, in_shape, torch_kFloat32, torch_kCPU, in_layout)
+    out_tensor = torch_tensor_from_blob(c_loc(out_data), out_dims, out_shape, torch_kFloat32, torch_kCPU, out_layout)
+
+    call torch_module_forward(model, in_tensor, n_inputs, out_tensor)
+
+    ! Clean up.
+    call torch_tensor_delete(out_tensor)
+    do ii = 1, n_inputs
+      call torch_tensor_delete(in_tensor(ii))
+    end do
+
+    call cpu_time(end_time)
+
+    durations(i) = end_time-start_time
+    ! the forward model is deliberately non-symmetric to check for difference in Fortran and C--type arrays.
+    write(msg, '(A, I8, A, F10.3, A)') "check iteration ", i, " (", durations(i), " s)"
+    print *, trim(msg)
+    write (*,*) out_data(1, 1000)
+    ! call assert_real_2d(big_array, big_result/2., test_name=msg)
+  end do
+
+  call print_time_stats(durations)
+
+
+  call torch_module_delete(model)
+
+  deallocate(in_data)
+  deallocate(out_data)
+  deallocate(durations)
+
+end program benchmark_resnet_test

--- a/resnetmodel/README.md
+++ b/resnetmodel/README.md
@@ -1,0 +1,7 @@
+# instructions
+
+* pt2ts.py - use this script to generate the `.pt` saved model in torchscript format
+* resnet18.py - this is called from the forpy fortran code `../benchmarker_resnet_forpy.f90`
+* resnet_infer_python.py - this can be used to run the model in python
+* saved_resnet18_model_cpu.pt - this is the torchscript saved model that is loaded in fortran using the direct coupling method
+  in `../benchmarker_resnet_torch.f90`

--- a/resnetmodel/pt2ts.py
+++ b/resnetmodel/pt2ts.py
@@ -1,0 +1,160 @@
+"""Load a pytorch model and convert it to TorchScript."""
+from typing import Optional
+import torch
+
+# FPTLIB-TODO
+# Add a module import with your model here:
+# This example assumes the model architecture is in an adjacent module `my_ml_model.py`
+import resnet18
+
+
+def script_to_torchscript(
+    model: torch.nn.Module, filename: Optional[str] = "scripted_model.pt"
+) -> None:
+    """
+    Save pyTorch model to TorchScript using scripting.
+
+    Parameters
+    ----------
+    model : torch.NN.Module
+        a pyTorch model
+    filename : str
+        name of file to save to
+    """
+    print("Saving model using scripting...", end="")
+    # FIXME: torch.jit.optimize_for_inference() when PyTorch issue #81085 is resolved
+    scripted_model = torch.jit.script(model)
+    # print(scripted_model.code)
+    scripted_model.save(filename)
+    print("done.")
+
+
+def trace_to_torchscript(
+    model: torch.nn.Module,
+    dummy_input: torch.Tensor,
+    filename: Optional[str] = "traced_model.pt",
+) -> None:
+    """
+    Save pyTorch model to TorchScript using tracing.
+
+    Parameters
+    ----------
+    model : torch.NN.Module
+        a pyTorch model
+    dummy_input : torch.Tensor
+        appropriate size Tensor to act as input to model
+    filename : str
+        name of file to save to
+    """
+    print("Saving model using tracing...", end="")
+    # FIXME: torch.jit.optimize_for_inference() when PyTorch issue #81085 is resolved
+    traced_model = torch.jit.trace(model, dummy_input)
+    # traced_model.save(filename)
+    frozen_model = torch.jit.freeze(traced_model)
+    ## print(frozen_model.graph)
+    ## print(frozen_model.code)
+    frozen_model.save(filename)
+    print("done.")
+
+
+def load_torchscript(filename: Optional[str] = "saved_model.pt") -> torch.nn.Module:
+    """
+    Load a TorchScript from file.
+
+    Parameters
+    ----------
+    filename : str
+        name of file containing TorchScript model
+    """
+    model = torch.jit.load(filename)
+
+    return model
+
+
+if __name__ == "__main__":
+    # =====================================================
+    # Load model and prepare for saving
+    # =====================================================
+
+    # FPTLIB-TODO
+    # Load a pre-trained PyTorch model
+    # Insert code here to load your model as `trained_model`.
+    # This example assumes my_ml_model has a method `initialize` to load
+    # architecture, weights, and place in inference mode
+    trained_model = resnet18.initialize()
+
+    # Switch off specific layers/parts of the model that behave
+    # differently during training and inference.
+    # This may have been done by the user already, so just make sure here.
+    trained_model.eval()
+
+    # =====================================================
+    # Prepare dummy input and check model runs
+    # =====================================================
+
+    # FPTLIB-TODO
+    # Generate a dummy input Tensor `dummy_input` to the model of appropriate size.
+    # This example assumes two inputs of size (512x40) and (512x1)
+    trained_model_dummy_input_1 = torch.ones(1, 3, 224, 224)
+
+    # FPTLIB-TODO
+    # Uncomment the following lines to save for inference on GPU (rather than CPU):
+    # device = torch.device('cuda')
+    # trained_model = trained_model.to(device)
+    # trained_model.eval()
+    # trained_model_dummy_input_1 = trained_model_dummy_input_1.to(device)
+    # trained_model_dummy_input_2 = trained_model_dummy_input_2.to(device)
+
+    # FPTLIB-TODO
+    # Run model for dummy inputs
+    # If something isn't working This will generate an error
+    trained_model_dummy_output = trained_model(
+        trained_model_dummy_input_1,
+    )
+
+    # =====================================================
+    # Save model
+    # =====================================================
+
+    # FPTLIB-TODO
+    # Set the name of the file you want to save the torchscript model to:
+    saved_ts_filename = "saved_resnet18_model_cpu.pt"
+
+    # FPTLIB-TODO
+    # Save the pytorch model using either scripting (recommended where possible) or tracing
+    # -----------
+    # Scripting
+    # -----------
+    script_to_torchscript(trained_model, filename=saved_ts_filename)
+
+    # -----------
+    # Tracing
+    # -----------
+    # trace_to_torchscript(trained_model, trained_model_dummy_input, filename=saved_ts_filename)
+
+    print(f"Saved model to TorchScript in '{saved_ts_filename}'.")
+
+    # =====================================================
+    # Check model saved OK
+    # =====================================================
+
+    # Load torchscript and run model as a test
+    # FPTLIB-TODO
+    # Scale inputs as above and, if required, move inputs and mode to GPU
+    trained_model_dummy_input_1 = 2.0 * trained_model_dummy_input_1
+    trained_model_testing_output = trained_model(
+        trained_model_dummy_input_1,
+    )
+    ts_model = load_torchscript(filename=saved_ts_filename)
+    ts_model_output = ts_model(
+        trained_model_dummy_input_1,
+    )
+
+    if torch.all(ts_model_output.eq(trained_model_testing_output)):
+        print("Saved TorchScript model working as expected in a basic test.")
+        print("Users should perform further validation as appropriate.")
+    else:
+        raise RuntimeError(
+            "Saved Torchscript model is not performing as expected.\n"
+            "Consider using scripting if you used tracing, or investigate further."
+        )

--- a/resnetmodel/resnet18.py
+++ b/resnetmodel/resnet18.py
@@ -1,0 +1,100 @@
+"""Load and run pretrained ResNet-18 from TorchVision."""
+
+import torch
+import torch.nn.functional as F
+import torchvision
+from torch import load, device, no_grad, reshape, zeros, tensor, float64, jit, from_numpy
+
+
+# Initialize everything
+def initialize_ts(*args):
+    """
+    Initialize a StrideNet model from torchscript.
+
+    """
+
+    filename, = args
+    model = jit.load(filename)
+
+    return model
+
+
+# Initialize everything
+def initialize():
+    """
+    Download pre-trained ResNet-18 model and prepare for inference.
+
+    Returns
+    -------
+    model : torch.nn.Module
+    """
+
+    # Load a pre-trained PyTorch model
+    print("Loading pre-trained ResNet-18 model...", end="")
+    model = torchvision.models.resnet18(weights='IMAGENET1K_V1')
+    print("done.")
+
+    # Switch-off some specific layers/parts of the model that behave
+    # differently during training and inference
+    model.eval()
+
+    return model
+
+
+def run_model(model):
+    """
+    Run the pre-trained ResNet-18 with dummy input of ones.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+    """
+
+    print("Running ResNet-18 model for ones...", end="")
+    dummy_input = torch.ones(1, 3, 224, 224)
+    output = model(dummy_input)
+    top5 = F.softmax(output, dim=1).topk(5).indices
+    print("done.")
+
+    print(f"Top 5 results:\n  {top5}")
+
+
+# Compute drag
+def compute(*args):
+    """
+    Run the computation from inputs.
+
+    Takes in input arguments passed from Fortran via Forpy and outputs another Tensor
+    Reshaping & porting to torch.tensor type, and applying model.forward is performed.
+
+    Parameters
+    __________
+    model : nn.Module
+        StrideNet model ready to be deployed.
+    BigTensor : torch.Tensor
+        Large 2D Tensor to operate on
+
+    Returns
+    -------
+    Y_out :
+        Results to be returned to MiMA
+    """
+    model, BigTensor, Y_out = args
+
+    BigTensor = from_numpy(BigTensor)
+
+    # Apply model.
+    with no_grad():
+        # Ensure evaluation mode (leave training mode and stop using current batch stats)
+        # model.eval()  # Set during initialisation
+        assert model.training is False
+        temp = model(BigTensor)
+
+    Y_out[:, :] = temp
+
+    return Y_out
+
+
+if __name__ == "__main__":
+    rn_model = initialize()
+    run_model(rn_model)

--- a/resnetmodel/resnet_infer_python.py
+++ b/resnetmodel/resnet_infer_python.py
@@ -1,0 +1,56 @@
+"""Load ResNet-18 saved to TorchScript and run inference with ones."""
+
+import torch
+
+
+def deploy(saved_model, device, batch_size=1):
+    """
+    Load TorchScript ResNet-18 and run inference with Tensor of ones.
+
+    Parameters
+    ----------
+    saved_model : str
+        location of ResNet-18 saved to Torchscript
+    device : str
+        Torch device to run model on, 'cpu' or 'cuda'
+    batch_size : int
+        batch size to run (default 1)
+
+    Returns
+    -------
+    output : torch.Tensor
+        result of running inference on model with Tensor of ones
+    """
+
+    input_tensor = torch.ones(batch_size, 3, 224, 224)
+
+    if device == "cpu":
+        # Load saved TorchScript model
+        model = torch.jit.load(saved_model)
+        # Inference
+        output = model.forward(input_tensor)
+
+    elif device == "cuda":
+        # All previously saved modules, no matter their device, are first
+        # loaded onto CPU, and then are moved to the devices they were saved
+        # from, so we don't need to manually transfer the model to the GPU
+        model = torch.jit.load(saved_model)
+        input_tensor_gpu = input_tensor.to(torch.device("cuda"))
+        output_gpu = model.forward(input_tensor_gpu)
+        output = output_gpu.to(torch.device("cpu"))
+
+    return output
+
+
+if __name__ == "__main__":
+
+    saved_model_file = "saved_resnet18_model_cpu.pt"
+
+    device_to_run = "cpu"
+    # device = "cuda"
+
+    batch_size_to_run = 1
+
+    result = deploy(saved_model_file, device_to_run, batch_size_to_run)
+
+    print(result[0, 999])


### PR DESCRIPTION
We want to add resnet example to the benchmarks to test compare performance of the direct coupling and forpy approaches.

This is a work in progress.

- [x] add simple test program for resnet
- [ ] use realistic input data for resnet and assert result vs. pure python code
- [ ] refactor benchmarks
- [ ] abstract model selection away from hardcode params