### PR TITLE
Fix assertion when specifying tolerance

### DIFF
--- a/benchmarker_utils.f90
+++ b/benchmarker_utils.f90
@@ -26,6 +26,8 @@ contains
 
     if (.not. present(rtol_opt)) then
       rtol = 1e-5
+    else
+      rtol = rtol_opt
     end if
 
     relative_error = maxval(abs(a/b - 1.))


### PR DESCRIPTION
Resolves #15

Depends on #11

Simple fix to ensure `rtol` is set to `rtol_opt`, if it is specified. 